### PR TITLE
ML-1414 - Add editable (via Custom Variables) custom email text in al…

### DIFF
--- a/app/code/Magebit/CustomEmail/Setup/Patch/Data/AddEmailTextVariable.php
+++ b/app/code/Magebit/CustomEmail/Setup/Patch/Data/AddEmailTextVariable.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * SchemaPatch
+ *
+ * @category     Magebit
+ * @package      Magebit_CustomEmail
+ * @author       Niks Veinbergs
+ * @copyright    Copyright (c) 2023 Magebit, Ltd.(https://www.magebit.com/)
+ */
+
+declare(strict_types=1);
+
+namespace Magebit\CustomEmail\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Class AddEmailTextVariable
+ */
+class AddEmailTextVariable implements DataPatchInterface
+{
+    /**
+     * @var ModuleDataSetupInterface
+     */
+    private $moduleDataSetup;
+
+    /**
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+    }
+
+    /**
+     * Description.
+     *Add email-text Custom variable to variable table
+     *
+     * @return void
+     */
+    public function apply(): void
+    {
+        $this->moduleDataSetup->startSetup();
+
+        $data[] = [
+            'code' => 'email-text',
+            'name' => 'email-text'
+        ];
+
+        $this->moduleDataSetup->getConnection()->insertArray(
+            $this->moduleDataSetup->getTable('variable'),
+            ['code', 'name'],
+            $data
+        );
+        $this->moduleDataSetup->endSetup();
+    }
+
+    /**
+     * Description.
+     *
+     *
+     * @return array|string[]
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+
+    /**
+     * Description.
+     *
+     *
+     * @return array|string[]
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+}

--- a/app/code/Magebit/CustomEmail/etc/module.xml
+++ b/app/code/Magebit/CustomEmail/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magebit_CustomEmail" setup_version="1.0.0"/>
+</config>

--- a/app/code/Magebit/CustomEmail/registration.php
+++ b/app/code/Magebit/CustomEmail/registration.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author       Niks Veinbergs
+ * @copyright    Copyright (c) 2023
+ */
+declare(strict_types=1);
+
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Magebit_CustomEmail',
+    __DIR__
+);

--- a/app/design/frontend/Venustheme/fasony/Magento_Email/email/header.html
+++ b/app/design/frontend/Venustheme/fasony/Magento_Email/email/header.html
@@ -1,0 +1,60 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<!--@subject {{trans "Header"}} @-->
+<!--@vars {
+"var logo_url":"Email Logo Image URL",
+"var logo_alt":"Email Logo Alt Text",
+"var logo_height":"Email Logo Image Height",
+"var logo_width":"Email Logo Image Width",
+"var template_styles|raw":"Template CSS"
+} @-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+        {{var template_styles|raw}}
+
+        {{css file="css/email.css"}}
+    </style>
+</head>
+<body>
+{{inlinecss file="css/email-inline.css"}}
+
+<!-- Begin wrapper table -->
+<table class="wrapper" width="100%">
+    <tr>
+        <td class="wrapper-inner" align="center">
+            <table class="main" align="center">
+                <tr>
+                    <td class="header">
+                        <a class="logo" href="{{store url=""}}">
+                        <img
+                                {{if logo_width}}
+                                width="{{var logo_width}}"
+                                {{else}}
+                                width="180"
+                                {{/if}}
+
+                        {{if logo_height}}
+                        height="{{var logo_height}}"
+                        {{/if}}
+
+                        src="{{var logo_url}}"
+                        alt="{{var logo_alt}}"
+                        border="0"
+                        />
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="main-content">
+                        <!-- Begin Content -->
+                        {{customVar code=email-text}}


### PR DESCRIPTION
…l transactional emails.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
1.Magento_Email header.html template changed inside Venustheme/fasony
2."email-text" custom variable added to "variable" table

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. In System -> Custom Variables -> email-text variable "HTML Value" field needs to be filled to append on emails.
2. Send a few transactional emails.
3. New text should be visible in all transactional emails.
4. Change the text
5. Repeat 2&3 steps.
